### PR TITLE
Alias `reorder_by*` functions to `reorder_*`, allowing package import

### DIFF
--- a/trendvis/__init__.py
+++ b/trendvis/__init__.py
@@ -30,7 +30,9 @@ from .ystack_brokenx import broken_x
 
 from .colorplots import discrete_colorplot
 
-from .plot_accessory import set_yticks, set_xticks, reorder_sort, reorder_index
+from .plot_accessory import (set_yticks, set_xticks,
+                             reorder_bysort as reorder_sort,
+                             reorder_byindex as reorder_index)
 
 from .ystack import multi_y
 


### PR DESCRIPTION
Alternatively, these function names could just be changed in `plot_accessory.py`. I was concerned that might break other functions expecting `reorder_bysort` and similar, but am happy to edit this if you like.